### PR TITLE
Support being placed in vendor

### DIFF
--- a/resources/views/edit-add.blade.php
+++ b/resources/views/edit-add.blade.php
@@ -11,6 +11,6 @@
 
 @section('javascript')
 	<script>
-		<?php include(base_path('hooks/voyager-polls/app.js')); ?>
+		<?php include(VOYAGER_POLLS_PATH.'/app.js'); ?>
 	</script>
 @endsection

--- a/src/PollsServiceProvider.php
+++ b/src/PollsServiceProvider.php
@@ -20,6 +20,8 @@ class PollsServiceProvider extends \Illuminate\Support\ServiceProvider
 
 	public function register()
 	{
+		define('VOYAGER_POLLS_PATH', __DIR__.'/..');
+		
 		app(Dispatcher::class)->listen('voyager.admin.routing', [$this, 'addPollsRoutes']);
 		app(Dispatcher::class)->listen('voyager.menu.display', [$this, 'addPollsMenuItem']);
 	}
@@ -27,7 +29,7 @@ class PollsServiceProvider extends \Illuminate\Support\ServiceProvider
 	public function boot(\Illuminate\Routing\Router $router, Dispatcher $events)
 	{
 		$this->pollRoutesAPI($router);
-		$this->loadViewsFrom(base_path('hooks/voyager-polls/resources/views'), 'polls');
+		$this->loadViewsFrom(__DIR__.'/../resources/views', 'polls');
 		$this->loadModels();
 	}
 


### PR DESCRIPTION
When a hook is created for testing locally, it's placed inside the `hooks` folder.
When downloaded using Composer, it's placed inside the `composer` folder.